### PR TITLE
Español: "house" -> "home page"

### DIFF
--- a/loc/ui/characterswitch.js
+++ b/loc/ui/characterswitch.js
@@ -28,7 +28,7 @@ export default {
     en: 'Home',
     ru: 'Домой',
     hi: 'मुख्य स्क्रीन',
-    es: 'Casa',
+    es: 'Inicio',
     de: 'Startseite',
     fr: 'Accueil',
     ko: '홈페이지',


### PR DESCRIPTION
"Casa" refers to a physical house in Spanish, whereas "Inicio" is used to refer to the landing page of a website.