### PR TITLE
Turkish translation update for swords

### DIFF
--- a/loc/items/sword.js
+++ b/loc/items/sword.js
@@ -49,7 +49,7 @@ export default [
       sv: 'Inte mycket bättre än ett trubbigt träslag enligt min åsikt.',
       ko: '내 의견으로는 뭉툭한 나무 조각보다 낫지 않습니다.',
       ro: 'Nu cu mult mai bun decât o bucată de lemn tocit, în opinia mea.',
-      tr: 'Bence künt bir ahşap parçasından çok daha iyi değil.',
+      tr: 'Bence körelmiş bir ahşap parçasından çok da iyi değil.',
       da: 'Ikke meget bedre end et stumt stykke træ efter min mening.'
     }
   },
@@ -76,7 +76,7 @@ export default [
       sv: 'Blir jag lurad?',
       ko: '내가 장난하는거야?',
       ro: 'Asta e o glumă?',
-      tr: 'Bana şaka mı yapıyorsun',
+      tr: 'Trolleniyor muyum?',
       da: 'Bliver jeg trollet?'
     }
   },
@@ -103,7 +103,7 @@ export default [
       sv: 'En del riddare släppte detta. Förmodligen oavsiktligt.',
       ko: '어떤 기사가 이것을 떨어 뜨 렸습니다. 아마도 우연히.',
       ro: 'Un cavaler a scăpat asta. Probabil neintenționat.',
-      tr: 'Bir şövalye bunu düşürdü. Muhtemelen kasıtsız.',
+      tr: 'Bir şövalye bunu düşürdü. Muhtemelen bilerek değil.',
       da: 'Nogle ridder faldt dette. Sandsynligvis utilsigtet.'
     }
   },
@@ -130,7 +130,7 @@ export default [
       sv: 'Lång? Ja. Dödligt? Kanske. Skär inte dig själv.',
       ko: '긴? 예. 치명적인? 아마도. 그냥 자르지 마.',
       ro: 'Lungă? Da. Mortală? Poate. Doar ai grijă să nu te tai.',
-      tr: 'Uzun? evet. ölümcül? belki. Sadece kendini kesme.',
+      tr: 'Uzun? Evet. Ölümcül? Belki. Sadece kendini kesme.',
       da: 'Lang? Ja. Dødelig? Måske. Skær bare ikke dig selv.'
     }
   },
@@ -156,7 +156,7 @@ export default [
       sv: 'Bruten skuren från benen av en gammal behemoth.',
       ko: '고대 거물의 뼈에서 날카롭게 새겨 져있다.',
       ro: 'Sculptată grosolan din oasele unui monstru behemoth.',
-      tr: 'Antik bir yaratığın kemiğinden dikkatsizce oyulmuş',
+      tr: 'Antik bir yaratığın kemiğinden kabaca oyulmuş.',
       da: 'Grovt skåret ud af knoglerne i en gammel behemoth.'
     }
   },
@@ -182,7 +182,7 @@ export default [
       sv: 'Ett svärd så mäktigt att få kan hantera det. Det är ganska tungt.',
       ko: '몇 명만이 그것을 처리 할 수있는 강력한 칼. 꽤 무거워.',
       ro: 'O sabie atât de puternică încât puțini o pot mânui. E destul de grea.',
-      tr: 'O kadar güçlü bir kılıç ki, sadece birkaçı halledebilir. Oldukça ağır.',
+      tr: 'O kadar güçlü bir kılıç ki, sadece bazı kişiler kullanabilir. Oldukça ağır.',
       da: 'Et sværd så mægtigt, at få kan klare det. Det er ret tungt.'
     }
   },
@@ -208,7 +208,7 @@ export default [
       sv: 'Djävulskt krökt blad. Även hålla det får dig att känna sin mörka kärna.',
       ko: '악마 모양의 곡선 칼날. 그것을 들고 있어도 당신은 어둠의 본질을 느낄 수 있습니다.',
       ro: 'Lamă curbată diabolic. Doar ținând-o poți să-i simți esența întunecată.',
-      tr: 'koyu kavisli bıçak. Karanlık özünü sadece tutarak hissedebilirsiniz.',
+      tr: 'Kavisli şeytani kılıç. Karanlık özünü sadece tutarak bile hissedebilirsiniz.',
       da: 'Diabolisk buet blad. Selv at holde det får dig til at føle sin mørke essens.'
     }
   },
@@ -235,7 +235,7 @@ export default [
       sv: 'Ett kallt blad med en brinnande het kant',
       ko: '불타는 뜨거운 가장자리가있는 차가운 모양의 날',
       ro: 'O lamă cu aspect rece și o margine ce arde fierbinte.',
-      tr: 'Yanan sıcak kenarlı soğuk görünümlü bir bıçak',
+      tr: 'Yanan, sıcak kenarlı, soğuk görünümlü bir kılıç.',
       da: 'Et koldt klinge med en brændende varm kant.'
     }
   },
@@ -262,7 +262,7 @@ export default [
       sv: 'Cylindriskt svärd stulet från en gammal kung. Klippkapacitet är ifrågasättande.',
       ko: '고대의 왕이 원통형 칼을 훔쳤다. 절단 능력에 의문의 여지가 있습니다.',
       ro: 'Sabie cilindrică furată de la un rege antic. Capabilitatea de tăiere este discutabilă.',
-      tr: 'Eski bir kraldan çalınan silindirik kılıç. Bu kılıcın yeteneği belirsiz.',
+      tr: 'Eski bir kraldan çalınan silindirik kılıç. Keskinliği tartışılabilir.',
       da: 'Cylindrisk sværd stjålet fra en gammel konge. Klippeevne er tvivlsom.'
     }
   },
@@ -289,7 +289,7 @@ export default [
       sv: 'Ett blad som varar av endast de mest skickliga riddarna.',
       ko: '가장 숙련 된 기사들만이 휘두르는 칼날.',
       ro: 'O lamă mânuită doar de cei mai pricepuți cavaleri.',
-      tr: 'Sadece en yetenekli şövalyeler tarafından kullanılan bir bıçak.',
+      tr: 'Sadece en yetenekli şövalyeler tarafından kullanılan bir kılıç.',
       da: 'Et kniv varet af kun de mest dygtige riddere.'
     }
   },
@@ -316,7 +316,7 @@ export default [
       sv: 'Kraftfullt mästerverk som tagits från underjordens avgrundar.',
       ko: '지하 세계의 무덤에서 가져온 강력한 걸작.',
       ro: 'O capodoperă puternică adusă din abisurile lumii de dincolo.',
-      tr: 'Yeraltı dünyasının uçurumlarından getirilen güçlü başyapıt',
+      tr: 'Yeraltı dünyasının çatlaklarından getirilen güçlü bir başyapıt.',
       da: 'Kraftigt mesterværk bragt fra undergrundens afgrund.'
     }
   },
@@ -343,7 +343,7 @@ export default [
       sv: 'Mystiskt rosa svärd. Graveringar säger "Mächtig Zerstörer".',
       ko: '신비한 핑크색 칼. 조각은 "Mächtig Zerstörer""라고합니다.',
       ro: 'Misterioasa sabie roz. Gravurile spun "Mächtig Zerstorer".',
-      tr: 'Gizemli pembe kılıç. Kazınmış kelimeler "Mächtig Zerstörer".',
+      tr: 'Gizemli, pembe bir kılıç. Kazınmış kelimeler: "Mächtig Zerstörer".',
       da: 'Mystisk rosa sværd. Graveringer siger "Mächtig Zerstörer".'
     }
   },
@@ -370,7 +370,7 @@ export default [
       sv: 'Förhinder levande vävnad som det pungar sig in i den tjocka muskeln av dina fiender som slår hjärta.',
       ko: '심장을 때리는 적의 두꺼운 근육 속으로 빠져들면서 조직을 파괴합니다.',
       ro: 'Devorează țesutul viu în timp ce-și face loc în mușchiul gros al inimii bătânde a dușmanilor tăi.',
-      tr: 'Kılıç düşmanın kalbine girerken dokuları yok eder',
+      tr: 'Bu kılıç düşmanın kalbine girerken dokuları yok eder.',
       da: 'Uddanner levende væv, da det plunges vej ind i dine fjenders tykke muskel, der slår hjerte.'
     }
   },
@@ -424,7 +424,7 @@ export default [
       sv: 'Vi fick höra att det drogs från sten. Fortfarande kan inte hitta stenen.',
       ko: '우리는 돌에서 꺼냈다 고 들었다. 아직도 돌을 찾을 수 없습니다.',
       ro: 'Ni s-a spus că a fost scoasă din piatră. Piatra încă nu a fost găsită.',
-      tr: 'Bu kılıcın bir taştan çekildiği söylendi, ama taşı bulamıyoruz.',
+      tr: 'Bu kılıcın bir taştan çekildiği söylendi. Ama taşı bulamıyoruz.',
       da: 'Vi fik at vide, at det blev trukket fra sten. Stadig kan ikke finde stenen.'
     }
   },
@@ -451,7 +451,7 @@ export default [
       sv: 'Detta vapen ger upphov till en ny ålder.',
       ko: '이 무기는 새로운 시대를 열어줍니다.',
       ro: 'Această armă aduce începutul unei noi ere.',
-      tr: 'Bu silah yeni bir çağın şafağını getiriyor',
+      tr: 'Bu silah yeni bir çağın şafağını getiriyor.',
       da: 'Dette våben giver anledning til en ny tids alder.'
     }
   }


### PR DESCRIPTION
(Turkish) Corrected/updated 'Rusty Ironsword', 'Troll Blade', 'Broadsword', 'Longsword', 'Gladius', 'Greatsword', 'Nullfire Sword', 'Ghastly Scimitar', 'Knight's Rapier', 'King's Glaive', 'Void Blade', 'Zerstörer', 'Hearteater', 'Excalibur', 'Harbinger'.