### PR TITLE
Change Haste french translation

### DIFF
--- a/loc/ui/stats.js
+++ b/loc/ui/stats.js
@@ -211,7 +211,7 @@ export default {
       ru: 'Ск.Умен',
       es: 'Rapidez',
       pt: 'Rapidez',
-      fr: 'Célérité',
+      fr: 'Hâte',
       tr: 'Çabukluk',
       hu: 'Sietség',
       zh: '匆忙',


### PR DESCRIPTION
"Hâte" is more accurate translation of Haste than "Célérité", especialy for a MMO