### PR TITLE
Update French Translations Setting.js

### DIFF
--- a/loc/ui/settings.js
+++ b/loc/ui/settings.js
@@ -195,7 +195,7 @@ export default {
     hi: 'ग्राफ़िक्स',
     es: 'Gráficos',
     de: 'Grafik',
-    fr: 'Graphiques',
+    fr: 'Graphismes',
     nl: 'Grafischen',
     tr: 'Grafikler',
     pt: 'Gráficos',


### PR DESCRIPTION
Little but important mistake ("Graphismes" is used in every video games while "Graphiques" is never used, just a little google translate error)